### PR TITLE
remove events suffix from cloudwatch events name

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_log_group" "this" {
 
 resource "aws_cloudwatch_event_rule" "this" {
   count               = var.enable_cw_event ? 1 : 0
-  name_prefix         = "${var.git}-${var.name}-events"
+  name                = "${var.git}-${var.name}"
   description         = "executes event"
   schedule_expression = var.schedule_expression
 }

--- a/iam.tf
+++ b/iam.tf
@@ -16,7 +16,6 @@ data "aws_iam_policy_document" "this" {
       type        = "Service"
     }
   }
-
 }
 
 resource "aws_iam_role_policy_attachment" "lambda" {


### PR DESCRIPTION
* switch from name prefix to name and remove events suffix